### PR TITLE
Add initial Erlang switchboard skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # ErlangSwitchboard
 An aggressive use of Codex from OpenAI to see what is possible.
+
+## Switchboard Application
+
+This project provides a minimal Erlang application that can relay output from one AI provider to another. The core API is `switchboard:relay/3` which accepts an input string and two provider modules.
+
+Example usage (in an Erlang shell):
+
+```
+1> switchboard:relay(<<"Hello">>, ai_chatgpt, ai_gemini).
+```
+
+Provider modules implement the `ai_base` behaviour. The included modules `ai_chatgpt` and `ai_gemini` are placeholders that simply echo the input.

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,3 @@
+{erl_opts, [warnings_as_errors]}.
+{deps, []}.
+{shell, [{apps, [switchboard]}]}.

--- a/src/ai_base.erl
+++ b/src/ai_base.erl
@@ -1,0 +1,3 @@
+-module(ai_base).
+
+-callback call(binary(), map()) -> {ok, binary()} | {error, term()}.

--- a/src/ai_chatgpt.erl
+++ b/src/ai_chatgpt.erl
@@ -1,0 +1,10 @@
+-module(ai_chatgpt).
+-behaviour(ai_base).
+
+-export([call/2]).
+
+call(Message, Config) when is_binary(Message), is_map(Config) ->
+    %% Placeholder for actual HTTP request to OpenAI ChatGPT API
+    io:format("ChatGPT called with ~p\n", [Message]),
+    %% In real implementation, use httpc:request with API key in Config
+    {ok, <<"chatgpt response to ", Message/binary>>}.

--- a/src/ai_gemini.erl
+++ b/src/ai_gemini.erl
@@ -1,0 +1,9 @@
+-module(ai_gemini).
+-behaviour(ai_base).
+
+-export([call/2]).
+
+call(Message, Config) when is_binary(Message), is_map(Config) ->
+    %% Placeholder for actual HTTP request to Gemini API
+    io:format("Gemini called with ~p\n", [Message]),
+    {ok, <<"gemini response to ", Message/binary>>}.

--- a/src/switchboard.app.src
+++ b/src/switchboard.app.src
@@ -1,0 +1,6 @@
+{application, switchboard,
+ [{description, "AI API switchboard"},
+  {vsn, "0.1.0"},
+  {registered, []},
+  {mod, {switchboard_app, []}},
+  {applications, [kernel, stdlib, inets]}]}.

--- a/src/switchboard.erl
+++ b/src/switchboard.erl
@@ -1,0 +1,12 @@
+-module(switchboard).
+
+-export([relay/3]).
+
+-spec relay(binary(), module(), module()) -> {ok, binary()} | {error, term()}.
+relay(Message, ProviderFrom, ProviderTo) when is_binary(Message) ->
+    case ProviderFrom:call(Message, #{}) of
+        {ok, Response} ->
+            ProviderTo:call(Response, #{});
+        Error ->
+            Error
+    end.

--- a/src/switchboard_app.erl
+++ b/src/switchboard_app.erl
@@ -1,0 +1,11 @@
+-module(switchboard_app).
+-behaviour(application).
+
+%% Application callbacks
+-export([start/2, stop/1]).
+
+start(_StartType, _StartArgs) ->
+    switchboard_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/src/switchboard_sup.erl
+++ b/src/switchboard_sup.erl
@@ -1,0 +1,15 @@
+-module(switchboard_sup).
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+%% supervisor callbacks
+-export([init/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    ChildSpecs = [],
+    {ok, { {one_for_one, 5, 10}, ChildSpecs}}.


### PR DESCRIPTION
## Summary
- create initial Erlang OTP application structure
- implement simple `switchboard` module with `relay/3`
- add stub AI provider modules for ChatGPT and Gemini
- document basic usage in README

## Testing
- `rebar3` and `erl` were not available so no compilation was performed