### PR TITLE
Add CI, Docker setup and basic tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+_build
+eb
+rebar.lock
+*.beam

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -1,0 +1,21 @@
+name: Erlang CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '26'
+          rebar3-version: '3.22.1'
+      - name: Compile
+        run: rebar3 compile
+      - name: Run tests
+        run: rebar3 eunit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM erlang:26-alpine
+WORKDIR /app
+COPY . .
+RUN rebar3 compile
+CMD ["rebar3","shell"]

--- a/README.md
+++ b/README.md
@@ -12,3 +12,24 @@ Example usage (in an Erlang shell):
 ```
 
 Provider modules implement the `ai_base` behaviour. The included modules `ai_chatgpt` and `ai_gemini` are placeholders that simply echo the input.
+
+## Running Tests
+
+The project uses `rebar3` and includes eunit tests. Run them with:
+
+```
+rebar3 eunit
+```
+
+## Docker
+
+A simple `Dockerfile` is provided for running the application in a container:
+
+```
+docker build -t erlang-switchboard .
+docker run -it erlang-switchboard
+```
+
+## Continuous Integration
+
+GitHub Actions are configured to compile and test the application automatically on pushes and pull requests to the `main` branch.

--- a/test/error_provider.erl
+++ b/test/error_provider.erl
@@ -1,0 +1,7 @@
+-module(error_provider).
+-behaviour(ai_base).
+
+-export([call/2]).
+
+call(_Message, _Config) ->
+    {error, test_error}.

--- a/test/switchboard_tests.erl
+++ b/test/switchboard_tests.erl
@@ -1,0 +1,9 @@
+-module(switchboard_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+relay_success_test() ->
+    Expected = {ok, <<"gemini response to chatgpt response to hello">>},
+    ?assertEqual(Expected, switchboard:relay(<<"hello">>, ai_chatgpt, ai_gemini)).
+
+relay_error_test() ->
+    ?assertEqual({error, test_error}, switchboard:relay(<<"hello">>, error_provider, ai_gemini)).


### PR DESCRIPTION
## Summary
- add an Erlang GitHub Actions workflow
- provide a Dockerfile and dockerignore
- document test and Docker usage
- add eunit tests for `switchboard`

## Testing
- `rebar3 eunit` *(fails: `rebar3: command not found`)*